### PR TITLE
Add confirmation before deleting assistant

### DIFF
--- a/app/controllers/settings/assistants_controller.rb
+++ b/app/controllers/settings/assistants_controller.rb
@@ -12,7 +12,7 @@ class Settings::AssistantsController < Settings::ApplicationController
     @assistant = Current.user.assistants.new(assistant_params)
 
     if @assistant.save
-      redirect_to edit_settings_assistant_path(@assistant), notice: "Assistant was successfully created."
+      redirect_to edit_settings_assistant_path(@assistant), notice: "Saved"
     else
       render :new, status: :unprocessable_entity
     end
@@ -20,7 +20,7 @@ class Settings::AssistantsController < Settings::ApplicationController
 
   def update
     if @assistant.update(assistant_params)
-      redirect_to edit_settings_assistant_path(@assistant), notice: "Assistant was successfully updated.", status: :see_other
+      redirect_to edit_settings_assistant_path(@assistant), notice: "Saved", status: :see_other
     else
       render :edit, status: :unprocessable_entity
     end
@@ -28,7 +28,7 @@ class Settings::AssistantsController < Settings::ApplicationController
 
   def destroy
     @assistant.destroy!
-    redirect_to new_settings_assistant_url, notice: "Assistant was successfully destroyed.", status: :see_other
+    redirect_to new_settings_assistant_url, notice: "Deleted", status: :see_other
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import Rails from "@rails/ujs"
+Rails.start()

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
-import Rails from "@rails/ujs"
-Rails.start()

--- a/app/views/settings/assistants/edit.html.erb
+++ b/app/views/settings/assistants/edit.html.erb
@@ -6,7 +6,7 @@
   <%= button_to "Delete",
         settings_assistant_path(@assistant),
         method: :delete,
-        data: { confirm: "Are you sure?" },
+        data: { turbo_confirm: "Are you sure?" },
         form: { class: "inline-block" },
         class: %|
           ml-5 mt-2 py-3 px-5

--- a/app/views/settings/assistants/edit.html.erb
+++ b/app/views/settings/assistants/edit.html.erb
@@ -3,5 +3,16 @@
 
   <%= render "form", assistant: @assistant %>
 
-  <%= button_to "Delete", settings_assistant_path(@assistant), method: :delete, class: "ml-5 mt-2 rounded-lg py-3 px-5 bg-white border border-gray-300 dark:bg-gray-500 dark:border-gray-500 font-medium", form: { class: "inline-block" } %>
+  <%= button_to "Delete",
+        settings_assistant_path(@assistant),
+        method: :delete,
+        data: { confirm: "Are you sure?" },
+        form: { class: "inline-block" },
+        class: %|
+          ml-5 mt-2 py-3 px-5
+          bg-white dark:bg-gray-500
+          border border-gray-300 dark:border-gray-500
+          rounded-lg
+          font-medium
+        | %>
 </div>

--- a/test/system/settings/assistants_test.rb
+++ b/test/system/settings/assistants_test.rb
@@ -36,6 +36,8 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
       click_text "Delete", match: :first
     end
     assert_text "Deleted"
+
+    refute Assistant.exists?(id: @assistant.id)
   end
 
   test "should cancel destroy Assistant" do
@@ -44,5 +46,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
       click_text "Delete", match: :first
     end
     assert_no_text "Deleted"
+
+    assert @assistant.reload.present?
   end
 end

--- a/test/system/settings/assistants_test.rb
+++ b/test/system/settings/assistants_test.rb
@@ -15,7 +15,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
 
     click_on "Save"
 
-    assert_text "Assistant was successfully created"
+    assert_text "Saved"
   end
 
   test "should update Assistant" do
@@ -27,13 +27,22 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
 
     click_on "Save"
 
-    assert_text "Assistant was successfully updated"
+    assert_text "Saved"
   end
 
   test "should destroy Assistant" do
     visit edit_settings_assistant_url(@assistant)
-    click_text "Delete", match: :first
+    accept_confirm do
+      click_text "Delete", match: :first
+    end
+    assert_text "Deleted"
+  end
 
-    assert_text "Assistant was successfully destroyed"
+  test "should cancel destroy Assistant" do
+    visit edit_settings_assistant_url(@assistant)
+    dismiss_confirm do
+      click_text "Delete", match: :first
+    end
+    assert_no_text "Deleted"
   end
 end


### PR DESCRIPTION
I accidentally deleted my assistant. :)

@robacarp I just discovered that when I added `data: { confirm: "Are you sure?" }` to the form button and it didn't work. I tracked it down to this removal of UJS. ChatGPT is telling me that there is some baseline rails functionality such as this delete confirmation that are still handled by UJS and that it can coexist with stimulus, so this PR adds it back. Any thoughts?