### PR TITLE
Add an animated reveal to signup form + make it not hideable

### DIFF
--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -17,12 +17,12 @@ export default class extends Controller {
   }
 
   connect() {
-    this.applied = false
+    this.toggled = false
     if (this.afterTimeoutValue) setTimeout(() => this.toggleClasses(), this.afterTimeoutValue)
   }
 
   toggleClass() {
-    this.applied = !this.applied
+    this.toggled = !this.toggled
 
     this.transitionableTargets.forEach(element => {
       this.toggleClasses.forEach(className => {
@@ -35,8 +35,8 @@ export default class extends Controller {
     window.dispatchEvent(new CustomEvent('right-column-changed'))
   }
 
-  applyClass() { // will only toggle once
-    if (this.applied) return
+  toggleClassOnce() {
+    if (this.toggled) return
     this.toggleClass()
   }
 }

--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -17,16 +17,26 @@ export default class extends Controller {
   }
 
   connect() {
-    if (this.afterTimeoutValue) setTimeout(() => this.toggleClass(), this.afterTimeoutValue)
+    this.applied = false
+    if (this.afterTimeoutValue) setTimeout(() => this.toggleClasses(), this.afterTimeoutValue)
   }
 
   toggleClass() {
+    this.applied = !this.applied
+
     this.transitionableTargets.forEach(element => {
-      element.classList.toggle(...this.toggleClasses)
+      this.toggleClasses.forEach(className => {
+        element.classList.toggle(className)
+      })
     })
 
     // Showing and hiding elements can cause the page to flow differently, very similarly to what happens when the
     // browser size changes. Throw this event in case we have other listeners on the resize event.
     window.dispatchEvent(new CustomEvent('right-column-changed'))
+  }
+
+  applyClass() { // will only toggle once
+    if (this.applied) return
+    this.toggleClass()
   }
 }

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -22,7 +22,7 @@
         class: "flex flex-col space-y-4 w-80",
         data: {
           controller: "transition",
-          transition_toggle_class: "!flex"
+          transition_toggle_class: "max-h-0 max-h-40"
         } do
   |f| %>
     <%= f.hidden_field :personable_type, id: "personable_type", value: "User" %>
@@ -42,11 +42,18 @@
           <%= user_fields.password_field :password,
             placeholder: "Password",
             class: "w-44 border-0",
-            data: { action: "focus->transition#toggleClass transition#toggleClass" }
+            data: { action: "focus->transition#applyClass" }
           %>
         <% end %>
 
-        <div class="<%= @person.errors.any? ? 'flex' : 'hidden' %> flex-col space-y-4" data-transition-target="transitionable">
+        <div  class="
+                    <%= @person.errors.any? ? 'max-h-40' : 'max-h-0' %> overflow-hidden
+                    flex flex-col
+                    transition-all duration-100 ease-in
+                    space-y-4
+                    "
+              data-transition-target="transitionable">
+
           <%= user_fields.label :first_name, class: "input input-bordered flex items-center justify-between" do %>
             <span>First name <span class="">*</span></span>
             <%= user_fields.text_field :first_name,

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -42,7 +42,7 @@
           <%= user_fields.password_field :password,
             placeholder: "Password",
             class: "w-44 border-0",
-            data: { action: "focus->transition#applyClass" }
+            data: { action: "focus->transition#toggleClassOnce" }
           %>
         <% end %>
 

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -6,7 +6,7 @@ class UsersTest < ApplicationSystemTestCase
     visit root_url
   end
 
-  test "the new user form reveals more fields when password is focused" do
+  test "the new user form reveals more fields when password is focused and those fields stay" do
     click_text "Sign up", match: :first
 
     assert_visible "#person_email", wait: 0.2
@@ -16,8 +16,19 @@ class UsersTest < ApplicationSystemTestCase
     assert_hidden "#person_personable_attributes_last_name"
     assert_hidden "#person_personable_attributes_openai_key"
 
-    fill_in "Email", with: "tester@test.com"
+    fill_in "Email", with: "email@email.com"
     fill_in "Password", with: "secret"
+
+    sleep 0.1
+
+    assert_visible "#person_personable_attributes_first_name"
+    assert_visible "#person_personable_attributes_last_name"
+    assert_visible "#person_personable_attributes_openai_key"
+
+    fill_in "Email", with: "changed@email.com"
+    fill_in "Password", with: "secret" # this triggers a second focus event
+
+    sleep 0.1
 
     assert_visible "#person_personable_attributes_first_name"
     assert_visible "#person_personable_attributes_last_name"


### PR DESCRIPTION
Small bug: when you focus on the password field, the additional fields on the signup form reveal. But if you focused again then they would hide.

I introduced a new method: toggleClassOnce() which ensures that classes toggle once but again.

While I was at it, I made this transition slide do a quick progressive reveal so the page is less jumpy.

![Zight Recording 2024-02-28 at 05 40 28 PM](https://github.com/the-dot-bot/hostedgpt/assets/35061/e572a6c9-cd8b-4ac7-ac55-dd892dc0cab2)
