### PR TITLE
Re-requesting messages and other streaming improvements

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -83,3 +83,18 @@ input:-webkit-autofill:active {
 input:focus {
   --tw-ring-color: #ffffff !important;
 }
+
+/* Animations */
+
+.animate-blink {
+  animation: blink 1.2s steps(1, start) infinite;
+}
+
+@keyframes blink {
+  0%, 40% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -98,3 +98,16 @@ input:focus {
     opacity: 1;
   }
 }
+
+.animate-breathe {
+  animation: breathe 1.3s linear infinite;
+}
+
+@keyframes breathe {
+  0%, 80%, 100% {
+    transform: scale(1)
+  }
+  40% {
+    transform: scale(1.3)
+  }
+}

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -39,7 +39,8 @@ class MessagesController < ApplicationController
 
   def update
     if @message.update(message_params)
-      redirect_to @message, notice: "Message was successfully updated.", status: :see_other
+      GetNextAIMessageJob.perform_later(@message.id, @message.conversation.assistant.id)
+      redirect_to conversation_messages_path(@message.conversation)
     else
       render :edit, status: :unprocessable_entity
     end
@@ -76,6 +77,6 @@ class MessagesController < ApplicationController
   end
 
   def message_params
-    params.require(:message).permit(:conversation_id, :content_text, documents_attributes: [:file])
+    params.require(:message).permit(:conversation_id, :content_text, :rerequested_at, documents_attributes: [:file])
   end
 end

--- a/app/jobs/get_next_a_i_message_job.rb
+++ b/app/jobs/get_next_a_i_message_job.rb
@@ -65,14 +65,14 @@ class GetNextAIMessageJob < ApplicationJob
   def generation_should_be_cancelled?
     @message.cancelled? ||
       message_is_populated? ||
-      (message_is_not_latest_in_conversation && @message.not_rerequested?)
+      (message_is_not_latest_in_conversation? && @message.not_rerequested?)
   end
 
   def message_is_populated?
     @message.content_text.present?
   end
 
-  def message_is_not_latest_in_conversation
+  def message_is_not_latest_in_conversation?
     @message != @conversation.latest_message
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -20,7 +20,6 @@ class Message < ApplicationRecord
   scope :ordered, -> { order(:created_at) }
 
   after_create :start_assistant_reply, if: -> { user? }
-  after_create_commit :broadcast_message
 
   private
 
@@ -38,9 +37,5 @@ class Message < ApplicationRecord
 
   def start_assistant_reply
     conversation.messages.create! role: :assistant, content_text: "", assistant: conversation.assistant
-  end
-
-  def broadcast_message
-    broadcast_append_to conversation, partial: "messages/message", locals: { scroll_down: true, timestamp: (Time.current.to_f*1000).to_i }
   end
 end

--- a/app/services/a_i_backends/open_a_i.rb
+++ b/app/services/a_i_backends/open_a_i.rb
@@ -14,10 +14,11 @@ class AIBackends::OpenAI
     end
   end
 
-  def initialize(user, assistant, conversation)
+  def initialize(user, assistant, conversation, message)
     @client = self.class.client.new(access_token: user.openai_key)
     @assistant = assistant
     @conversation = conversation
+    @message = message
   end
 
   def get_next_chat_message(&chunk_received_handler)
@@ -54,7 +55,7 @@ class AIBackends::OpenAI
   end
 
   def existing_messages
-    @conversation.messages.ordered.collect do |message|
+    @conversation.messages.ordered.where("id < ?", @message.id).collect do |message|
       if @assistant.images && message.documents.present?
 
         content = [{ type: "text", text: message.content_text }]

--- a/app/services/a_i_backends/open_a_i.rb
+++ b/app/services/a_i_backends/open_a_i.rb
@@ -55,7 +55,7 @@ class AIBackends::OpenAI
   end
 
   def existing_messages
-    @conversation.messages.ordered.where("id < ?", @message.id).collect do |message|
+    @conversation.messages.ordered.where("created_at < ?", @message.created_at).collect do |message|
       if @assistant.images && message.documents.present?
 
         content = [{ type: "text", text: message.content_text }]

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -75,7 +75,8 @@
                   role: "regenerate",
                 },
                 params: { message: { content_text: nil, rerequested_at: Time.current } },
-                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white contents" do
+                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white",
+                form_class: "inline-block h-[18px]" do
           %>
             <%= icon "arrow-path", variant: :outline, size: 18, title: "Regenerate" %>
           <% end %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -43,7 +43,7 @@
 
       <%# This div needs to be tightly wrapped around the content_text output because the whitespace formatting is important. %>
       <div class="whitespace-pre-wrap" data-role="content-text" data-clipboard-target="text"
-        ><%= message.content_text %><div class="animate-blink w-3 h-1 bg-black inline-block ml-1 -mb-1 <%= !thinking && 'hidden' %>"></div></div>
+        ><%= message.content_text %><div class="animate-breathe w-3 h-3 rounded-full bg-black inline-block ml-1 <%= !thinking && 'hidden' %>"></div></div>
 
       <div class="flex justify-start invisible gap-2 mt-2 text-gray-600 dark:text-gray-300 group-hover:visible">
         <% if message.user? %>

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,10 +1,17 @@
-<%# locals: (message:, scroll_down: false, only_scroll_down_if_was_bottom: false, request_id: nil, timestamp: nil, message_counter: -1) -%>
+<%# locals: (message:, scroll_down: false, only_scroll_down_if_was_bottom: false, request_id: nil, timestamp: nil, thinking: nil, message_counter: -1) -%>
 <%# request_id is not used, but broadcasting turbo stream messages provides it as a local so it needs to be accepted %>
 
 <% max_index = message.conversation.messages.length - 1 %>
 <% last_message = message_counter == max_index %>
 <% initial_page_load = last_message && !scroll_down %>
 <% scroll_down = scroll_down || initial_page_load %>
+<% thinking = if thinking.nil?
+                (last_message && message.content_text.blank?) ||
+                (message.rerequested? && message.content_text.blank?)
+              else
+                thinking
+              end
+%>
 
 <div
   id="<%= dom_id message %>"
@@ -35,7 +42,8 @@
       <% end %>
 
       <%# This div needs to be tightly wrapped around the content_text output because the whitespace formatting is important. %>
-      <div class="whitespace-pre-wrap" data-role="content-text" data-clipboard-target="text"><%= message.content_text %></div>
+      <div class="whitespace-pre-wrap" data-role="content-text" data-clipboard-target="text"
+        ><%= message.content_text %><div class="animate-blink w-3 h-1 bg-black inline-block ml-1 -mb-1 <%= !thinking && 'hidden' %>"></div></div>
 
       <div class="flex justify-start invisible gap-2 mt-2 text-gray-600 dark:text-gray-300 group-hover:visible">
         <% if message.user? %>
@@ -61,11 +69,13 @@
             <%= icon "clipboard", variant: :outline, size: 18, title: "Copy", data: { transition_target: "transitionable" } %>
             <%= icon "check", variant: :outline, size: 18, title: "Copied!", data: { transition_target: "transitionable" }, class: "hidden" %>
           <% end %>
-          <%= button_tag type: "button",
+          <%= button_to message_path(message),
+                method: :patch,
                 data: {
                   role: "regenerate",
                 },
-                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white" do
+                params: { message: { content_text: nil, rerequested_at: Time.current } },
+                class: "cursor-pointer hover:text-gray-900 dark:hover:text-white contents" do
           %>
             <%= icon "arrow-path", variant: :outline, size: 18, title: "Regenerate" %>
           <% end %>

--- a/db/migrate/20240305023107_add_timestamps_to_messages.rb
+++ b/db/migrate/20240305023107_add_timestamps_to_messages.rb
@@ -1,0 +1,6 @@
+class AddTimestampsToMessages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :messages, :rerequested_at, :datetime
+    add_column :messages, :cancelled_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_07_231451) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_05_023107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -105,6 +105,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_07_231451) do
     t.bigint "content_document_id"
     t.bigint "run_id"
     t.bigint "assistant_id", null: false
+    t.datetime "rerequested_at"
+    t.datetime "cancelled_at"
     t.index ["assistant_id"], name: "index_messages_on_assistant_id"
     t.index ["content_document_id"], name: "index_messages_on_content_document_id"
     t.index ["conversation_id"], name: "index_messages_on_conversation_id"

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -62,9 +62,9 @@ class MessagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "should update message" do
-    patch message_url(@message), params: { message: { role: @message.role, content_text: @message.content_text } }
-    assert_redirected_to message_url(@message)
+  test "should update message with a re-request" do
+    patch message_url(@conversation.latest_message), params: { message: { content_text: nil, rerequested_at: Time.current } }
+    assert_redirected_to conversation_messages_url(@conversation)
   end
 
   test "should destroy message" do

--- a/test/jobs/get_next_a_i_message_job_test.rb
+++ b/test/jobs/get_next_a_i_message_job_test.rb
@@ -7,13 +7,37 @@ class GetNextAIMessageJobTest < ActiveJob::TestCase
     @test_client = TestClients::OpenAI.new(access_token: 'abc')
   end
 
-  test "adds a new message from the assistant" do
+  test "populates the latest message from the assistant" do
     assert_no_difference "@conversation.messages.reload.length" do
       assert GetNextAIMessageJob.perform_now(@message.id, assistants(:samantha).id)
     end
 
     message_text = @test_client.chat.dig("choices", 0, "message", "content")
     assert_equal message_text, @conversation.latest_message.content_text
+  end
+
+  test "re-populates an earlier message from the assistant if it was provided and marked as re-requested" do
+    messages(:yes_i_do).update!(rerequested_at: Time.current, content_text: nil)
+
+    assert_no_difference "@conversation.messages.reload.length" do
+      assert GetNextAIMessageJob.perform_now(messages(:yes_i_do).id, assistants(:samantha).id)
+    end
+
+    message_text = @test_client.chat.dig("choices", 0, "message", "content")
+    assert_equal message_text, messages(:yes_i_do).reload.content_text
+    assert_not_equal message_text, @conversation.latest_message.content_text
+  end
+
+  test "returns early if attempting to re-populate an earlier message from the assistant if it was provided but NOT marked as re-requested" do
+    messages(:yes_i_do).update!(content_text: nil)
+
+    assert_no_difference "@conversation.messages.reload.length" do
+      refute GetNextAIMessageJob.perform_now(messages(:yes_i_do).id, assistants(:samantha).id)
+    end
+
+    message_text = @test_client.chat.dig("choices", 0, "message", "content")
+    assert_not_equal message_text, messages(:yes_i_do).reload.content_text
+    assert_not_equal message_text, @conversation.latest_message.content_text
   end
 
   test "returns early if the message id was invalid" do
@@ -28,6 +52,8 @@ class GetNextAIMessageJobTest < ActiveJob::TestCase
     @message.update!(content_text: "Hello")
     refute GetNextAIMessageJob.perform_now(@message.id, assistants(:samantha).id)
   end
+
+  # TODO: Be sure to test for cancelled_at case when we finish implementing cancelled
 
   test "returns early if the user has replied after this" do
     @conversation.messages.create! role: :user, content_text: "Ignore that, new question:", assistant: @conversation.assistant

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -49,22 +49,6 @@ class MessageTest < ActiveSupport::TestCase
     end
   end
 
-  test "creating a message sends a turbo broadcast" do
-    message = Message.create!(
-      assistant: assistants(:samantha),
-      conversation: conversations(:greeting),
-      role: :user,
-      content_text: "test message"
-    )
-    assert_turbo_stream_broadcasts conversations(:greeting)
-    broadcasts = capture_turbo_stream_broadcasts conversations(:greeting)
-    assert_equal 2, broadcasts.length
-    assert_equal "append", broadcasts.first["action"], "First message should have been an append"
-    assert_match message.content_text, broadcasts.first.to_html, "First message should have been the user's message"
-    assert_equal "append", broadcasts.second["action"], "Second message should have been an append"
-    assert_match "", broadcasts.second.to_html, "Second message should have been an empty assistant message"
-  end
-
   test "creating a message with a conversation and Current.user set fails if conversation is not owned by the user" do
     Current.user = users(:rob)
     assistant = users(:rob).assistants.first

--- a/test/services/a_i_backends/open_a_i_test.rb
+++ b/test/services/a_i_backends/open_a_i_test.rb
@@ -4,7 +4,7 @@ module AIBackends
   class OpenAITest < ActiveSupport::TestCase
     setup do
       @conversation = conversations(:attachments)
-      @openai = OpenAI.new(users(:keith), assistants(:samantha), @conversation)
+      @openai = OpenAI.new(users(:keith), assistants(:samantha), @conversation, @conversation.latest_message)
       @test_client = TestClients::OpenAI.new(access_token: 'abc')
     end
 
@@ -19,9 +19,11 @@ module AIBackends
     test "existing_messages constructs a proper response and pivots on images" do
       existing_messages = @openai.send(:existing_messages)
 
-      assert_equal @conversation.messages.length, existing_messages.length
+      assert_equal @conversation.messages.length-1, existing_messages.length
 
       @conversation.messages.ordered.each_with_index do |message, i|
+        next if @conversation.messages.length == i+1
+
         if message.documents.present?
           assert_instance_of Array, existing_messages[i][:content]
           assert_equal message.documents.length+1, existing_messages[i][:content].length
@@ -29,6 +31,15 @@ module AIBackends
           assert_equal existing_messages[i][:content], message.content_text
         end
       end
+    end
+
+    test "existing_messages only considers messages up to the assistant message being generated" do
+      @openai = OpenAI.new(users(:keith), assistants(:samantha), @conversation, messages(:yes_i_can))
+
+      existing_messages = @openai.send(:existing_messages)
+
+      assert_equal 1, existing_messages.length
+      assert_equal existing_messages[0][:content], messages(:can_you_hear).content_text
     end
   end
 end

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -24,6 +24,19 @@ class ConversationMessagesTest < ApplicationSystemTestCase
     assert_shows_tooltip msg_clipboard, "Copy"
   end
 
+  test "regenerate icon shows properly, clears when clicked" do
+    click_text @long_conversation.title
+    sleep 0.2
+    msg = find_messages.last
+    msg.hover
+
+    msg_regenerate = msg.find("button[data-role='regenerate']")
+    msg_regenerate.hover
+    assert_shows_tooltip msg_regenerate, "Regenerate"
+
+    msg_regenerate.click
+  end
+
   test "the conversation auto-scrolls to bottom when page loads" do
     click_text @long_conversation.title
     sleep 0.2

--- a/test/system/conversations/messages_test.rb
+++ b/test/system/conversations/messages_test.rb
@@ -60,7 +60,7 @@ class ConversationMessagesTest < ApplicationSystemTestCase
     end
   end
 
-  test "submitting a message with ENTER inserts a new message with morphing & scrolls down" do
+  test "submitting a message with ENTER inserts two new messages with morphing & scrolls down" do
     visit conversation_messages_path(@long_conversation.id)
     scroll_to_bottom "#right-content"
 
@@ -79,15 +79,11 @@ class ConversationMessagesTest < ApplicationSystemTestCase
   end
 
   test "when the AI replies with a message it appears with morphing and scrolls down" do
+    new_message = @long_conversation.messages.create! assistant: @long_conversation.assistant, content_text: "Stub: ", role: :assistant
     click_text @long_conversation.title
     sleep 0.5
-    new_message = nil
 
-    assert_page_morphed do
-      new_message = @long_conversation.messages.create! assistant: @long_conversation.assistant, content_text: "Stub: ", role: :assistant
-      sleep 0.5
-      assert find_messages.last.text.include?("Stub:"), "The last message should have contained the submitted text"
-    end
+    assert find_messages.last.text.include?("Stub:"), "The last message should have contained the submitted text"
 
     assert_page_morphed do
       new_message.content_text = "The quick brown fox jumped over the lazy dog and this line needs to wrap to scroll." +


### PR DESCRIPTION
* Makes the re-generate button work beneath assistant responses (fixes #173)
* Show a blinking cursor while the client is waiting on the server
* Fix an issue that was still causing some flicker at the beginning of generation