### PR TITLE
Add support for Anthropic key in a user's settings

### DIFF
--- a/app/controllers/settings/application_controller.rb
+++ b/app/controllers/settings/application_controller.rb
@@ -8,9 +8,14 @@ class Settings::ApplicationController < ApplicationController
     # controller_name => array of items
     @settings_menu = {
       assistants: Current.user.assistants.ordered.map {
-                    |assistant| [ assistant, edit_settings_assistant_path(assistant) ]
-                  }.to_h,
-      people: { 'Account': edit_settings_person_path }
+        |assistant| [ assistant, edit_settings_assistant_path(assistant) ]
+      }.to_h.merge({
+        #'New Assistant': new_settings_assistant_path(assistant)
+      }),
+
+      people: {
+        'Account': edit_settings_person_path
+      }
     }
   end
 end

--- a/app/controllers/settings/people_controller.rb
+++ b/app/controllers/settings/people_controller.rb
@@ -6,7 +6,7 @@ class Settings::PeopleController < Settings::ApplicationController
 
   def update
     if Current.person.update(person_params)
-      redirect_to edit_settings_person_path, notice: "Person was successfully updated.", status: :see_other
+      redirect_to edit_settings_person_path, notice: "Saved", status: :see_other
     else
       @person = Current.person
       render :edit, status: :unprocessable_entity
@@ -16,7 +16,9 @@ class Settings::PeopleController < Settings::ApplicationController
   private
 
   def person_params
-    params.require(:person).permit(:email, personable_attributes: [:id, :first_name, :last_name, :password, :openai_key])
+    params.require(:person).permit(:email, personable_attributes: [
+      :id, :first_name, :last_name, :password, :openai_key, :anthropic_key
+    ])
   end
 
   def check_personable_id

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,26 +20,15 @@ class UsersController < ApplicationController
     end
   end
 
-  def update
-    user = Current.user
-    user.update(user_params)
-
-    if user.save
-      redirect_back fallback_location: "/", notice: "Account information saved.", status: :see_other
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
   private
 
   def person_params
     params.require(:person).permit(:email, :personable_type, personable_attributes: [
-      :first_name, :last_name, :password, :openai_key, :anthropic_key
+      :first_name, :last_name, :password
     ])
   end
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :openai_key, :anthropic_key)
+    params.require(:user).permit(:first_name, :last_name)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
 
   def update
     user = Current.user
-    user.update(update_params)
+    user.update(user_params)
 
     if user.save
       redirect_back fallback_location: "/", notice: "Account information saved.", status: :see_other
@@ -34,10 +34,12 @@ class UsersController < ApplicationController
   private
 
   def person_params
-    params.require(:person).permit(:email, :personable_type, personable_attributes: [:first_name, :last_name, :password, :openai_key])
+    params.require(:person).permit(:email, :personable_type, personable_attributes: [
+      :first_name, :last_name, :password, :openai_key, :anthropic_key
+    ])
   end
 
-  def update_params
-    params.require(:user).permit(:first_name, :last_name, :openai_key)
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :openai_key, :anthropic_key)
   end
 end

--- a/app/jobs/get_next_a_i_message_job.rb
+++ b/app/jobs/get_next_a_i_message_job.rb
@@ -39,6 +39,11 @@ class GetNextAIMessageJob < ApplicationJob
     puts "\nResponse cancelled" if Rails.env.development?
     wrap_up_the_message
     return true
+  rescue OpenAI::ConfigurationError => e
+    @message.content_text = "You do not have a valid API key for OpenAI. Click your Profile in the bottom left and " +
+      "then Settings. You will find OpenAI Key instructions."
+    wrap_up_the_message
+    return true
   rescue => e
     unless Rails.env.test?
       puts "\nError in GetNextAIMessageJob: #{e.inspect}"

--- a/app/jobs/get_next_a_i_message_job.rb
+++ b/app/jobs/get_next_a_i_message_job.rb
@@ -40,8 +40,8 @@ class GetNextAIMessageJob < ApplicationJob
     wrap_up_the_message
     return true
   rescue OpenAI::ConfigurationError => e
-    @message.content_text = "You do not have a valid API key for OpenAI. Click your Profile in the bottom left and " +
-      "then Settings. You will find OpenAI Key instructions."
+    @message.content_text = "You do not have a valid API key for OpenAI. Click your Profile in the bottom " +
+      "left and then Settings. You will find OpenAI Key instructions."
     wrap_up_the_message
     return true
   rescue => e

--- a/app/views/settings/assistants/edit.html.erb
+++ b/app/views/settings/assistants/edit.html.erb
@@ -14,5 +14,7 @@
           border border-gray-300 dark:border-gray-500
           rounded-lg
           font-medium
-        | %>
+        |
+  %>
+  <%= link_to "Cancel", root_path, class: "pl-3" %>
 </div>

--- a/app/views/settings/assistants/edit.html.erb
+++ b/app/views/settings/assistants/edit.html.erb
@@ -16,5 +16,5 @@
           font-medium
         |
   %>
-  <%= link_to "Cancel", root_path, class: "pl-3" %>
+  <%= link_to "Cancel", root_path, class: "float-right inline-block ml-5 mt-2 py-3" %>
 </div>

--- a/app/views/settings/people/_form.html.erb
+++ b/app/views/settings/people/_form.html.erb
@@ -35,9 +35,64 @@
       <%= user_fields.text_field :password, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
     </div>
 
-    <div class="my-5">
-      <%= user_fields.label :openai_key %>
-      <%= user_fields.text_field :openai_key, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full" %>
+    <div class="my-5" data-controller="transition" data-transition-toggle-class="hidden">
+      <%= user_fields.label :openai_key, "OpenAI Key (for GPT-3.5 & 4)" %>
+        <%= button_tag type: "button",
+          id: "how-openai",
+          class: "underline text-blue-600",
+          data: {
+            transition_target: "transitionable",
+            action: "transition#toggleClass",
+          } do
+        %>How do I get?
+        <% end %>
+      <ol data-transition-target="transitionable"
+          id="openai-instructions"
+          class="
+                  list-decimal
+                  my-3 p-2 pl-7
+                  border bg-gray-50 border-gray-200
+                  hidden
+                "
+      >
+        <li>Sign up for OpenAI's <%= link_to "Platform", "https://platform.openai.com/", class: "underline text-blue-600", target: "_blank" %>, you can sign in with your ChatGPT account.</li>
+        <li>Click "API Keys" on the left (or <%= link_to "take me to API Keys", "https://platform.openai.com/api-keys", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Verify your phone number.</li>
+        <li>Click "Create new secret key", name it something like "HostedGPT" and paste it below.</li>
+        <li>Ensure you have billing set up by clicking "Settings" and "Billing" (or <%= link_to "take me to Billing", "https://platform.openai.com/account/billing/overview", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Add a "Payment method."</li>
+      </ol>
+      <%= user_fields.text_field :openai_key, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "OpenAI Key" %>
+    </div>
+
+    <div class="my-5" data-controller="transition" data-transition-toggle-class="hidden">
+      <%= user_fields.label :anthropic_key, "Anthropic Key (for Claude 3)" %>
+        <%= button_tag type: "button",
+          id: "how-anthropic",
+          class: "underline text-blue-600",
+          data: {
+            transition_target: "transitionable",
+            action: "transition#toggleClass",
+          } do
+        %>How do I get?
+        <% end %>
+      <ol data-transition-target="transitionable"
+          id="anthropic-instructions"
+          class="
+                  list-decimal
+                  my-3 p-2 pl-7
+                  border bg-gray-50 border-gray-200
+                  hidden
+                "
+      >
+        <li>Sign up for Anthropic's web <%= link_to "Console", "https://console.anthropic.com/", class: "underline text-blue-600", target: "_blank" %>.</li>
+        <li>Click your profile in the top right and select "API Keys" (or <%= link_to "take me to API Keys", "https://console.anthropic.com/settings/keys", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Click "Create Key" and name it somethign like "HostedGPT."</li>
+        <li>Click "Copy key" and paste it below.</li>
+        <li>Then, click your profile and select "Plans & Billing" (or <%= link_to "take me to Plans", "https://console.anthropic.com/settings/plans", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Click "Claim" if you have any free credits or if you have no free credits click "Select Plan" and just pick the "Build" plan.</li>
+      </ol>
+      <%= user_fields.text_field :anthropic_key, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "Anthropic Key" %>
     </div>
   <% end %>
 

--- a/app/views/settings/people/_form.html.erb
+++ b/app/views/settings/people/_form.html.erb
@@ -46,8 +46,8 @@
           } do
         %>How do I get?
         <% end %>
-      <ol data-transition-target="transitionable"
-          id="openai-instructions"
+      <ol id="openai-instructions"
+          data-transition-target="transitionable"
           class="
                   list-decimal
                   my-3 p-2 pl-7
@@ -55,14 +55,30 @@
                   hidden
                 "
       >
-        <li>Sign up for OpenAI's <%= link_to "Platform", "https://platform.openai.com/", class: "underline text-blue-600", target: "_blank" %>, you can sign in with your ChatGPT account.</li>
-        <li>Click "API Keys" on the left (or <%= link_to "take me to API Keys", "https://platform.openai.com/api-keys", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Sign up for OpenAI's
+          <%= link_to "Platform", "https://platform.openai.com/",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>, you can sign in with your ChatGPT account.
+        </li>
+        <li>Click "API Keys" on the left (or
+          <%= link_to "take me to API Keys", "https://platform.openai.com/api-keys",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>).</li>
         <li>Verify your phone number.</li>
         <li>Click "Create new secret key", name it something like "HostedGPT" and paste it below.</li>
-        <li>Ensure you have billing set up by clicking "Settings" and "Billing" (or <%= link_to "take me to Billing", "https://platform.openai.com/account/billing/overview", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Ensure you have billing set up by clicking "Settings" and "Billing" (or
+          <%= link_to "take me to Billing", "https://platform.openai.com/account/billing/overview",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>).</li>
         <li>Add a "Payment method."</li>
       </ol>
-      <%= user_fields.text_field :openai_key, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "OpenAI Key" %>
+      <%= user_fields.text_field :openai_key,
+        class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full",
+        placeholder: "OpenAI Key"
+      %>
     </div>
 
     <div class="my-5" data-controller="transition" data-transition-toggle-class="hidden">
@@ -76,8 +92,8 @@
           } do
         %>How do I get?
         <% end %>
-      <ol data-transition-target="transitionable"
-          id="anthropic-instructions"
+      <ol id="anthropic-instructions"
+          data-transition-target="transitionable"
           class="
                   list-decimal
                   my-3 p-2 pl-7
@@ -85,18 +101,40 @@
                   hidden
                 "
       >
-        <li>Sign up for Anthropic's web <%= link_to "Console", "https://console.anthropic.com/", class: "underline text-blue-600", target: "_blank" %>.</li>
-        <li>Click your profile in the top right and select "API Keys" (or <%= link_to "take me to API Keys", "https://console.anthropic.com/settings/keys", class: "underline text-blue-600", target: "_blank" %>).</li>
+        <li>Sign up for Anthropic's web
+          <%= link_to "Console", "https://console.anthropic.com/",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>.
+        </li>
+        <li>Click your profile in the top right and select "API Keys" (or
+          <%= link_to "take me to API Keys", "https://console.anthropic.com/settings/keys",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>).
+        </li>
         <li>Click "Create Key" and name it somethign like "HostedGPT."</li>
         <li>Click "Copy key" and paste it below.</li>
-        <li>Then, click your profile and select "Plans & Billing" (or <%= link_to "take me to Plans", "https://console.anthropic.com/settings/plans", class: "underline text-blue-600", target: "_blank" %>).</li>
-        <li>Click "Claim" if you have any free credits or if you have no free credits click "Select Plan" and just pick the "Build" plan.</li>
+        <li>Then, click your profile and select "Plans & Billing" (or
+          <%= link_to "take me to Plans", "https://console.anthropic.com/settings/plans",
+            class: "underline text-blue-600",
+            target: "_blank"
+          %>).
+        </li>
+        <li>Click "Claim" if you have any free credits or if you have no free credits click
+          "Select Plan" and just pick the "Build" plan.
+        </li>
       </ol>
-      <%= user_fields.text_field :anthropic_key, class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full", placeholder: "Anthropic Key" %>
+      <%= user_fields.text_field :anthropic_key,
+        class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full",
+        placeholder: "Anthropic Key"
+      %>
     </div>
   <% end %>
 
   <div class="inline">
-    <%= form.submit "Save", class: "rounded-lg py-3 px-5 bg-gray-200 dark:bg-gray-900 border border-gray-400 inline-block font-medium cursor-pointer" %>
+    <%= form.submit "Save",
+      class: "rounded-lg py-3 px-5 bg-gray-200 dark:bg-gray-900 border border-gray-400 inline-block font-medium cursor-pointer"
+    %>
   </div>
 <% end %>

--- a/app/views/settings/people/_form.html.erb
+++ b/app/views/settings/people/_form.html.erb
@@ -136,6 +136,6 @@
     <%= form.submit "Save",
       class: "rounded-lg py-3 px-5 bg-gray-200 dark:bg-gray-900 border border-gray-400 inline-block font-medium cursor-pointer"
     %>
-    <%= link_to "Cancel", root_path, class: "pl-3" %>
+    <%= link_to "Cancel", root_path, class: "float-right inline-block ml-5 py-3" %>
   </div>
 <% end %>

--- a/app/views/settings/people/_form.html.erb
+++ b/app/views/settings/people/_form.html.erb
@@ -136,5 +136,6 @@
     <%= form.submit "Save",
       class: "rounded-lg py-3 px-5 bg-gray-200 dark:bg-gray-900 border border-gray-400 inline-block font-medium cursor-pointer"
     %>
+    <%= link_to "Cancel", root_path, class: "pl-3" %>
   </div>
 <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -69,14 +69,6 @@
               class: "w-44 border-0"
             %>
           <% end %>
-
-          <%= user_fields.label :openai_key, class: "input input-bordered flex items-center justify-between" do %>
-            OpenAI Key
-            <%= user_fields.text_field :openai_key,
-              placeholder: "OpenAI API Key",
-              class: "w-44 border-0"
-            %>
-          <% end %>
         </div>
     <% end %>
     <%= f.submit "Sign Up", class: 'rounded bg-gray-200 dark:bg-gray-900 border border-gray-400 font-medium p-4 text-center cursor-pointer' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
 
   resources :messages, except: [:new, :create, :index]
   resources :documents
-  resources :users, only: [:new, :create, :update]
+  resources :users, only: [:new, :create]
 
   get "up" => "rails/health#show", :as => :rails_health_check
 

--- a/db/migrate/20240308230245_add_anthropic_key_to_users.rb
+++ b/db/migrate/20240308230245_add_anthropic_key_to_users.rb
@@ -1,0 +1,5 @@
+class AddAnthropicKeyToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :anthropic_key, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_05_023107) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_230245) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -277,6 +277,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_05_023107) do
     t.string "first_name"
     t.string "last_name"
     t.string "openai_key"
+    t.string "anthropic_key"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -20,7 +20,7 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
     assert_current_path login_path, wait: 2
     fill_in "email", with: user.person.email
     fill_in "password", with: password
-    click_on "Log In"
+    click_text "Log In"
     assert_current_path new_assistant_message_path(assistant), wait: 2
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -39,7 +39,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     post users_url, params: {person: {personable_type: "User", email: email, personable_attributes: user_attr}}
 
     user = Person.find_by(email: email).user
-    assert_equal user_attr.except(:password), user.slice(:first_name, :last_name, :openai_key).symbolize_keys
+    assert_equal user_attr.except(:password), user.slice(:first_name, :last_name).symbolize_keys
     assert_equal 2, user.assistants.count
 
     assistant = user.assistants.ordered.first
@@ -51,6 +51,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   private
 
   def user_attr
-    { password: "secret", first_name: "John", last_name: "Doe", openai_key: "abc123xyz890" }
+    { password: "secret", first_name: "John", last_name: "Doe" }
   end
 end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -4,8 +4,10 @@ keith:
   password_digest: <%= BCrypt::Password.create('secret') %>
   registered_at: 2023-12-19 08:40:05
   openai_key: abc123
+  anthropic_key: def789
 
 rob:
   password_digest: <%= BCrypt::Password.create('secret') %>
   registered_at: 2023-12-26 08:40:05
   openai_key: abc123
+  anthropic_key: def789

--- a/test/system/settings/assistants_test.rb
+++ b/test/system/settings/assistants_test.rb
@@ -13,7 +13,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
     fill_in "Description", with: @assistant.description
     fill_in "Instructions", with: @assistant.instructions
 
-    click_on "Save"
+    click_text "Save"
 
     assert_text "Saved"
   end
@@ -25,7 +25,7 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
     fill_in "Description", with: @assistant.description+"-2"
     fill_in "Instructions", with: @assistant.instructions+"-2"
 
-    click_on "Save"
+    click_text "Save"
 
     assert_text "Saved"
   end

--- a/test/system/settings/people_test.rb
+++ b/test/system/settings/people_test.rb
@@ -14,6 +14,7 @@ class Settings::PeopleTest < ApplicationSystemTestCase
       first_name: @person.user.first_name+"-2",
       last_name: @person.user.last_name+"-2",
       openai_key: @person.user.openai_key+"-2",
+      anthropic_key: @person.user.anthropic_key+"-2",
     }
 
     assert_not_equal attr[:email], @person.reload.email
@@ -23,14 +24,15 @@ class Settings::PeopleTest < ApplicationSystemTestCase
     fill_in "First name", with: attr[:first_name]
     fill_in "Last name", with: attr[:last_name]
     fill_in "Password", with: "secret"
-    fill_in "Openai key", with: attr[:openai_key]
+    fill_in "OpenAI Key", with: attr[:openai_key]
+    fill_in "Anthropic Key", with: attr[:anthropic_key]
 
     click_on "Save"
 
-    assert_text "Person was successfully updated"
+    assert_text "Saved"
     assert_current_path edit_settings_person_url
 
     assert_equal attr[:email], @person.reload.email
-    assert_equal attr.except(:email), @person.user.slice(:first_name, :last_name, :openai_key).symbolize_keys
+    assert_equal attr.except(:email), @person.user.slice(:first_name, :last_name, :openai_key, :anthropic_key).symbolize_keys
   end
 end

--- a/test/system/settings/people_test.rb
+++ b/test/system/settings/people_test.rb
@@ -4,11 +4,10 @@ class Settings::PeopleTest < ApplicationSystemTestCase
   setup do
     @person = people(:keith_registered)
     login_as @person
+    visit edit_settings_person_url
   end
 
   test "should update Person" do
-    visit edit_settings_person_url
-
     attr = {
       email: @person.email+"-2",
       first_name: @person.user.first_name+"-2",
@@ -27,12 +26,28 @@ class Settings::PeopleTest < ApplicationSystemTestCase
     fill_in "OpenAI Key", with: attr[:openai_key]
     fill_in "Anthropic Key", with: attr[:anthropic_key]
 
-    click_on "Save"
+    click_text "Save"
 
     assert_text "Saved"
     assert_current_path edit_settings_person_url
 
     assert_equal attr[:email], @person.reload.email
     assert_equal attr.except(:email), @person.user.slice(:first_name, :last_name, :openai_key, :anthropic_key).symbolize_keys
+  end
+
+  test "clicking How? on OpenAI reveals instructions" do
+    assert_hidden "#openai-instructions"
+    click_element "#how-openai"
+
+    assert_visible "#openai-instructions"
+    assert_hidden "#how-openai"
+  end
+
+  test "clicking How? on Anthropic reveals instructions" do
+    assert_hidden "#anthropic-instructions"
+    click_element "#how-anthropic"
+
+    assert_visible "#anthropic-instructions"
+    assert_hidden "#how-anthropic"
   end
 end

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -14,7 +14,6 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_hidden "#person_personable_attributes_first_name"
     assert_hidden "#person_personable_attributes_last_name"
-    assert_hidden "#person_personable_attributes_openai_key"
 
     fill_in "Email", with: "email@email.com"
     fill_in "Password", with: "secret"
@@ -23,7 +22,6 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_visible "#person_personable_attributes_first_name"
     assert_visible "#person_personable_attributes_last_name"
-    assert_visible "#person_personable_attributes_openai_key"
 
     fill_in "Email", with: "changed@email.com"
     fill_in "Password", with: "secret" # this triggers a second focus event
@@ -32,7 +30,6 @@ class UsersTest < ApplicationSystemTestCase
 
     assert_visible "#person_personable_attributes_first_name"
     assert_visible "#person_personable_attributes_last_name"
-    assert_visible "#person_personable_attributes_openai_key"
   end
 
   test "should display errors if fields are left blank" do
@@ -50,7 +47,6 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "Password", with: "secret"
     fill_in "First name", with: "John"
     fill_in "Last name", with: "Doe"
-    fill_in "OpenAI Key", with: "abc123"
 
     click_text "Sign Up"
 


### PR DESCRIPTION
I've decided that I'm going to prioritize adding support for Claude 3 because I'm hearing from others that it's noticeably better than GPT-4. I'm anxious to try it out! I realized this could be the first "bonus" feature and it'll be even easier than the voice support, although I'm still working on that.

This PR is the first piece.

* Remove asking for OpenAI key on signup form
* After signing up, when you try chatting with either of the OpenAI assistants it explains how to visit your settings to add the OpenAI key
* The user settings page now has step-by-step instructions for adding the OpenAI Key and the Anthropic Key