### PR TITLE
Introducing full-page layout for login actions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,8 @@
 class SessionsController < ApplicationController
   include Accessible
 
+  layout "login"
+
   def new
   end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   include Accessible
 
-  layout "login"
+  layout "public"
 
   def new
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   include Accessible
 
+  layout "public"
+
   def new
     @person = Person.new
     @person.personable = User.new

--- a/app/views/application/_head.html.erb
+++ b/app/views/application/_head.html.erb
@@ -1,0 +1,14 @@
+<head>
+  <title>HostedGPT</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+  <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/daisyui@4.6.0/dist/full.min.css" %>
+  <%# daisyui (^) is declared above application (v) so we can override classes from it %>
+  <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag "application", 'https://fonts.googleapis.com/css?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap', "data-turbo-track": "reload" %>
+  <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+  <%= javascript_importmap_tags %>
+  <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
+  <%= content_for :head %>
+</head>

--- a/app/views/layouts/_settings_item.erb
+++ b/app/views/layouts/_settings_item.erb
@@ -30,7 +30,5 @@
     <span class="<%= !item.is_a?(Assistant) && "ml-1 text-base" %>">
       <%= item.to_s %>
     </span>
-
   <% end %>
-
 </div>

--- a/app/views/layouts/_toast.html.erb
+++ b/app/views/layouts/_toast.html.erb
@@ -1,4 +1,3 @@
-
 <% if flash.any? %>
   <div class="toast toast-top toast-end transition-transform duration-100 ease-in"
         data-controller="transition"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,31 +1,17 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>HostedGPT</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/daisyui@4.6.0/dist/full.min.css" %>
-    <%# daisyui (^) is declared above application (v) so we can override classes from it %>
-    <%= stylesheet_link_tag "tailwind", "inter-font", "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", 'https://fonts.googleapis.com/css?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap', "data-turbo-track": "reload" %>
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_importmap_tags %>
-    <%= turbo_refreshes_with method: :morph, scroll: :preserve %>
-    <%= content_for :head %>
-  </head>
+  <%= render "head" %>
   <body class="font-sans text-gray-950 dark:text-gray-100">
-    <div  class="flex h-screen"
-          data-controller="transition"
-          data-transition-toggle-class="!hidden"
+    <div class="flex h-screen"
+         data-controller="transition"
+         data-transition-toggle-class="!hidden"
     >
-      <div  id="left-column"
-            class="flex-col h-screen w-[260px] bg-gray-50 dark:bg-gray-900 hidden md:flex overflow-x-clip relative"
-            data-transition-target="transitionable"
+      <div id="left-column"
+           class="flex-col h-screen w-[260px] bg-gray-50 dark:bg-gray-900 hidden md:flex overflow-x-clip relative"
+           data-transition-target="transitionable"
       >
         <div id="left-content-container" class="flex-1 flex flex-col h-screen">
           <div id="left-scrollable" class="flex-grow pl-3 overflow-y-auto overflow-x-clip scrollbar-hide">
-
             <%= yield :left_column %>
           </div>
 

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <%= render "head" %>
+  <body class="font-sans text-gray-950 dark:text-gray-100">
+    <div class="flex h-screen"
+         data-controller="transition"
+         data-transition-toggle-class="!hidden"
+    >
+      <div class="flex flex-1 h-screen bg-white dark:bg-gray-800">
+        <%= content_for?(:body) ? yield(:body) : yield %>
+      </div>
+    </div>
+    <%= render "layouts/toast" %>
+  </body>
+</html>

--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -2,14 +2,10 @@
 <html>
   <%= render "head" %>
   <body class="font-sans text-gray-950 dark:text-gray-100">
-    <div class="flex h-screen"
-         data-controller="transition"
-         data-transition-toggle-class="!hidden"
-    >
+    <div class="flex h-screen">
       <div class="flex flex-1 h-screen bg-white dark:bg-gray-800">
         <%= content_for?(:body) ? yield(:body) : yield %>
       </div>
     </div>
-    <%= render "layouts/toast" %>
   </body>
 </html>

--- a/app/views/layouts/settings.html.erb
+++ b/app/views/layouts/settings.html.erb
@@ -1,5 +1,4 @@
 <% content_for :left_column do %>
-
   <div class="pl-2 py-7 text-3xl">
     Settings
   </div>
@@ -10,11 +9,9 @@
       </div>
     <% end %>
   </div>
-
 <% end %>
 
 <% content_for :body do %>
-
   <div id="wide-header" class="absolute right-0 ml-2 mt-2 mb-3 h-10 text-lg">
     <%= link_to root_path, class: "block cursor-pointer inline-flex mr-3 px-2 py-2 group", data: { role: "pencil" } do %>
       <%= icon "x-mark",
@@ -35,7 +32,6 @@
       <%= yield %>
     </div>
   </div>
-
 <% end %>
 
 <%= render template: "layouts/application" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,6 @@ Rails.application.routes.draw do
 
   get "up" => "rails/health#show", :as => :rails_health_check
 
-
   # routes to still be cleaned up:
 
   resources :chats, only: [:index, :show, :create]


### PR DESCRIPTION
Updated the design of login/register actions to full-page (instead of 2 columns).

<img width="1622" alt="Capture d’écran, le 2024-03-11 à 15 50 05" src="https://github.com/the-dot-bot/hostedgpt/assets/547754/350cec30-9ed2-433d-8a18-5fb957196509">

Also removed some extra lines (feel free to edit if not your taste) in other layout files.