### PR TITLE
Show the composer in disabled state while it is submitting

### DIFF
--- a/app/javascript/controllers/new_message_controller.js
+++ b/app/javascript/controllers/new_message_controller.js
@@ -27,7 +27,8 @@ export default class extends Controller {
   submitForm() {
     if (this.cleanInputValue.length > 0) {
       this.element.requestSubmit()
-      this.element.reset()
+      this.inputTarget.disabled = true
+      this.submitTarget.disabled = true
       window.dispatchEvent(new CustomEvent('right-column-changed'))
     }
   }

--- a/app/views/messages/_right_column.html.erb
+++ b/app/views/messages/_right_column.html.erb
@@ -177,6 +177,7 @@
               text-md
               rounded-2xl border-gray-600
               focus:ring-0 focus:border-gray-500 focus:shadow
+              disabled:text-gray-300 disabled:border-gray-200
               resize-none
             |
           %>


### PR DESCRIPTION
Fixes #122 

On slow internet connections, when you submit a chat message and it disappears but there is no visual indication that it's still processing the request. This is an attempt at creating a better "submitting" state.

<img width="782" alt="image" src="https://github.com/the-dot-bot/hostedgpt/assets/35061/dd73a02b-b187-4a63-8980-9ae0fba018db">
