### PR TITLE
Open a modal when ? is pressed

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -124,3 +124,9 @@ input:focus {
     transform: scale(1.3)
   }
 }
+
+/* Repeated visual components */
+
+.key {
+  @apply inline-block py-2 px-3 rounded-md border border-gray-300 text-sm min-w-9 text-center;
+}

--- a/app/assets/stylesheets/includes/daisyui_tooltip.css
+++ b/app/assets/stylesheets/includes/daisyui_tooltip.css
@@ -155,3 +155,10 @@
 .input {
   background-color: transparent;
 }
+
+/* Modal override */
+
+dialog button:focus,
+dialog button:focus-visible {
+  outline: none !important;
+}

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,7 +2,8 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   open(event) {
-    if (event.key != '?' || !event.shiftKey) return
+    if (event.key != '?' || !event.shiftKey || ["INPUT", "TEXTAREA"].includes(event.target.tagName)) return
+
     this.element.showModal()
   }
 }

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -1,0 +1,8 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  open(event) {
+    if (event.key != '?' || !event.shiftKey) return
+    this.element.showModal()
+  }
+}

--- a/app/javascript/controllers/new_message_controller.js
+++ b/app/javascript/controllers/new_message_controller.js
@@ -42,9 +42,7 @@ export default class extends Controller {
   }
 
   focusKeydown(event) {
-    // Don't steal the keypress if the input field is already focused
-    if (event.key == "/" && event.target.tagName != "BODY")
-      return
+    if (event.key == "/" && ["INPUT", "TEXTAREA"].includes(event.target.tagName)) return
 
     this.focusInput()
     event.preventDefault()

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -215,10 +215,60 @@
   data-controller="modal"
   data-action="keydown@document->modal#open"
 >
-  <div class="modal-box">
-    <h3 class="font-bold text-lg">Hello!</h3>
-    <p class="py-4">Press ESC key or click outside to close</p>
-  </div>
+  <main class="modal-box max-w-4xl">
+    <header class="font-bold text-lg mb-5">
+      Keyboard shortcuts
+    </header>
+    <article class="flex flex-col md:flex-row">
+      <section class="flex-1 pr-0 md:pr-5">
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Open new chat
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">Ctrl / ⌘</div>
+            <div class="key">J</div>
+          </kbd>
+        </figure>
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Focus chat input
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">/</div>
+          </kbd>
+        </figure>
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Unfocus chat input
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">ESC</div>
+          </kbd>
+        </figure>
+
+      </section>
+      <section class="flex-1 pl-0 md:pl-5">
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Toggle sidebar
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">Ctrl / ⌘</div>
+            <div class="key">.</div>
+          </kbd>
+        </figure>
+        <figure class="flex py-2">
+          <figcaption class="flex-grow flex items-center">
+            Show shortcuts
+          </figcaption>
+          <kbd class="w-40 text-right">
+            <div class="key">?</div>
+          </kbd>
+        </figure>
+      </section>
+    </article>
+  </main>
   <form method="dialog" class="modal-backdrop no-focus-outline">
     <button>close</button>
   </form>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -208,3 +208,19 @@
       </div>
   </footer>
 </turbo-frame>
+
+<dialog
+  id="tooltip-dialog"
+  class="modal no-focus-outline"
+  data-controller="modal"
+  data-action="keydown@document->modal#open"
+>
+  <div class="modal-box">
+    <h3 class="font-bold text-lg">Hello!</h3>
+    <p class="py-4">Press ESC key or click outside to close</p>
+  </div>
+  <form method="dialog" class="modal-backdrop no-focus-outline">
+    <button>close</button>
+  </form>
+</dialog>
+


### PR DESCRIPTION
Fixes #136 

Uses the Daisy UI modal and a little bit of stimulus in order to get this working:

<img width="943" alt="image" src="https://github.com/the-dot-bot/hostedgpt/assets/35061/263c5e58-7a50-4b8e-9962-a3ca6c63e103">

On narrow viewport it stacks:

<img width="577" alt="image" src="https://github.com/the-dot-bot/hostedgpt/assets/35061/4e2e3e8f-67e7-41ca-9a2d-b73e3aff9c94">

And it looks good in dark mode:

<img width="580" alt="image" src="https://github.com/the-dot-bot/hostedgpt/assets/35061/e60bcfe1-dd80-4aa7-b615-dd25b434d2ac">

The modal dismisses with ESC or by clicking outside of it.