### PR TITLE
Fix jumpiness of textarea

### DIFF
--- a/app/javascript/controllers/textarea_autogrow_controller.js
+++ b/app/javascript/controllers/textarea_autogrow_controller.js
@@ -9,6 +9,7 @@ export default class extends Controller {
   }
 
   connect() {
+    console.log('connect')
     this.element.style.overflow = 'hidden'
     this.autogrow()
 
@@ -25,10 +26,10 @@ export default class extends Controller {
 
   throttledAutogrow = throttle(() => this.autogrow(), 50)
   autogrow() {
-    const prevHeight = this.element.style.height
+    console.log('autogrow')
+    const prevHeight = getComputedStyle(this.element).height
     this.element.style.height = 'auto'
-    const newHeight = `${this.element.scrollHeight + 2}px`  // The +2 prevents jumping on load. The scrollHeight
-                                                            // from the actual height for the empty state.
+    const newHeight = `${this.element.scrollHeight+2}px` // scrollHeight is two less than computedHeight, this prevents jumps
     this.element.style.height = newHeight
 
     if (prevHeight != newHeight) window.dispatchEvent(new CustomEvent('main-column-changed'))

--- a/app/javascript/controllers/textarea_autogrow_controller.js
+++ b/app/javascript/controllers/textarea_autogrow_controller.js
@@ -9,24 +9,24 @@ export default class extends Controller {
   }
 
   connect() {
-    console.log('connect')
     this.element.style.overflow = 'hidden'
     this.autogrow()
 
     this.element.addEventListener('input', this.throttledAutogrow)
+    window.addEventListener('turbo:morph', () => this.throttledAutogrow)
     window.addEventListener('resize', this.throttledAutogrow)
     window.addEventListener('main-column-changed', this.throttledAutogrow)
   }
 
   disconnect() {
     this.element.removeEventListener('input', this.throttledAutogrow)
+    window.removeEventListener('turbo:morph', this.throttledAutogrow)
     window.removeEventListener('resize', this.throttledAutogrow)
     window.removeEventListener('main-column-changed', this.throttledAutogrow)
   }
 
   throttledAutogrow = throttle(() => this.autogrow(), 50)
   autogrow() {
-    console.log('autogrow')
     const prevHeight = getComputedStyle(this.element).height
     this.element.style.height = 'auto'
     const newHeight = `${this.element.scrollHeight+2}px` // scrollHeight is two less than computedHeight, this prevents jumps

--- a/app/views/settings/assistants/_form.html.erb
+++ b/app/views/settings/assistants/_form.html.erb
@@ -24,7 +24,7 @@
   <div class="my-5">
     <%= form.label :instructions %>
     <%= form.text_area :instructions,
-      class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full dark:text-black h-20",
+      class: "block shadow rounded-md border border-gray-200 outline-none px-3 py-2 mt-2 w-full dark:text-black h-18",
       data: { controller: "textarea-autogrow" }
     %>
   </div>


### PR DESCRIPTION
Within the /settings there are some textareas that autogrow. This is for your assistant's custom instructions.

When you save these and navigate away and come back, these textareas are jumpy. They autogrow to the height, but then were mistakenly shrinking back down and re-growing. I fixed it so they no longer do this incorrect jumpiness.