### PR TITLE
Fix the "after timeout" feature of transitions controller when morphing

### DIFF
--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -23,10 +23,14 @@ export default class extends Controller {
   transitionableTargetConnected() {
     if (this.afterTimeoutValue) {
       this.transitionableTarget.setAttribute('data-timer', 'true')
+      this.transitionableTarget.addEventListener("turbo:before-morph-element", this.boundTransitionableTargetReconnect, { once: true })
+      // These two lines above fix a tricky bug. The toast feature uses afterTimeout, however while the timeout is running if the page
+      // is refreshed and this refresh *also* includes a toast, this was causing the timer to fail. Without fully understanding why
+      // this was occurring, I fixed this by adding a data-timer attribute. By modifying the toast, I can guarantee a morph of this
+      // page will morph the toast back to remove this attribute. I then catch the fact that it's about to morph and do a clean
+      // disconnect and reconnect.
       this.timeoutHandler = setTimeout(() => this.toggleClass(), this.afterTimeoutValue)
     }
-
-    this.transitionableTarget.addEventListener("turbo:before-morph-element", this.boundTransitionableTargetReconnect, { once: true })
   }
 
   transitionableTargetDisconnected() {

--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -18,7 +18,30 @@ export default class extends Controller {
 
   connect() {
     this.on = false
-    if (this.afterTimeoutValue) setTimeout(() => this.toggleClass(), this.afterTimeoutValue)
+  }
+
+  transitionableTargetConnected() {
+    if (this.afterTimeoutValue) {
+      this.transitionableTarget.setAttribute('data-timer', 'true')
+      this.timeoutHandler = setTimeout(() => this.toggleClass(), this.afterTimeoutValue)
+    }
+
+    this.transitionableTarget.addEventListener("turbo:before-morph-element", this.boundTransitionableTargetReconnect, { once: true })
+  }
+
+  transitionableTargetDisconnected() {
+    if (!this.afterTimeoutValue) return
+
+    if (this.timeoutHandler) {
+      clearTimeout(this.timeoutHandler)
+      this.timeoutHandler = null
+    }
+  }
+
+  boundTransitionableTargetReconnect = () => { this.transitionableTargetReconnect() }
+  transitionableTargetReconnect() {
+    if (this.transitionableTargetDisconnected) this.transitionableTargetDisconnected()
+    if (this.transitionableTargetConnected) this.transitionableTargetConnected()
   }
 
   toggleClass() {

--- a/app/javascript/controllers/transition_controller.js
+++ b/app/javascript/controllers/transition_controller.js
@@ -25,10 +25,13 @@ export default class extends Controller {
       this.transitionableTarget.setAttribute('data-timer', 'true')
       this.transitionableTarget.addEventListener("turbo:before-morph-element", this.boundTransitionableTargetReconnect, { once: true })
       // These two lines above fix a tricky bug. The toast feature uses afterTimeout, however while the timeout is running if the page
-      // is refreshed and this refresh *also* includes a toast, this was causing the timer to fail. Without fully understanding why
-      // this was occurring, I fixed this by adding a data-timer attribute. By modifying the toast, I can guarantee a morph of this
-      // page will morph the toast back to remove this attribute. I then catch the fact that it's about to morph and do a clean
-      // disconnect and reconnect.
+      // is refreshed and this refresh *also* includes a toast, this was causing the toast to properly reappear but the timer was not
+      // re-run with this second appearance. This is because morphing does not, properly so, trigger stimulus controllers to be
+      // reconnect. Stimulus assumes their existing connection is just fine. It only reconnects if the element disappears and re-appears.
+      //
+      // But in order to get the proper behavior, if a page morph also includes a new toast, I want the timer to re-run. I I fixed this
+      // by adding a data-timer attribute to the toast div. By modifying the element, I can guarantee a morph of this page will morph
+      // the toast back. Then I catch the fact that the toast is about to morph and do a clean disconnect and reconnect.
       this.timeoutHandler = setTimeout(() => this.toggleClass(), this.afterTimeoutValue)
     }
   }

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -5,7 +5,8 @@
   class="
           rounded-lg mr-5 cursor-pointer group
           hover:bg-gray-100 dark:hover:bg-gray-700
-          relationship:bg-gray-200 dark:relationship:bg-gray-700 <%= selected && 'relationship' %>"
+          relationship:bg-gray-200 dark:relationship:bg-gray-700 <%= selected && 'relationship' %>
+        "
   data-role="conversation"
   data-radio-behavior-target="radio"
   data-radio-behavior-also-select-id="<%= conversation.assistant.id %>"
@@ -46,16 +47,32 @@
               class: "outline-none cursor-pointer group-hover:visible
                       hover:text-gray-600 dark:hover:text-gray-300
                       focus:text-gray-600 dark:focus:text-gray-300",
-              data: { controller: "nested-pointer" },
-              title: "Archive",
+              data: {
+                  controller: "nested-pointer",
+                  role: "delete"
+                },
+              title: "Delete",
               tooltip: :top,
               tabindex: 0,
               role: :button
         %>
 
         <ul tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 mt-7 dark:text-white dark:!bg-gray-700" data-controller="nested-pointer">
-          <li><a><%= icon "archive-box", variant: :outline, size: 18 %>Archive</a></li>
-          <li><a><%= icon "trash", variant: :outline, size: 18 %>Delete</a></li>
+          <li>
+            <%= button_to conversation_path(conversation),
+              method: :delete,
+              data: {
+                role: "confirm-delete",
+              },
+              class: "flex gap-2 w-full",
+              form: {
+                class: "inline-block",
+                data: { turbo_frame: "_top" },
+              } do
+            %>
+              <%= icon "trash", variant: :outline, size: 18 %>Delete
+            <% end %>
+          </li>
         </ul>
       </div>
 

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -47,32 +47,16 @@
               class: "outline-none cursor-pointer group-hover:visible
                       hover:text-gray-600 dark:hover:text-gray-300
                       focus:text-gray-600 dark:focus:text-gray-300",
-              data: {
-                  controller: "nested-pointer",
-                  role: "delete"
-                },
-              title: "Delete",
+              data: { controller: "nested-pointer" },
+              title: "Archive",
               tooltip: :top,
               tabindex: 0,
               role: :button
         %>
 
         <ul tabindex="0" class="dropdown-content z-10 menu p-2 shadow-xl bg-base-100 rounded-box w-52 mt-7 dark:text-white dark:!bg-gray-700" data-controller="nested-pointer">
-          <li>
-            <%= button_to conversation_path(conversation),
-              method: :delete,
-              data: {
-                role: "confirm-delete",
-              },
-              class: "flex gap-2 w-full",
-              form: {
-                class: "inline-block",
-                data: { turbo_frame: "_top" },
-              } do
-            %>
-              <%= icon "trash", variant: :outline, size: 18 %>Delete
-            <% end %>
-          </li>
+          <li><a><%= icon "archive-box", variant: :outline, size: 18 %>Archive</a></li>
+          <li><a><%= icon "trash", variant: :outline, size: 18 %>Delete</a></li>
         </ul>
       </div>
 

--- a/test/system/settings/assistants_test.rb
+++ b/test/system/settings/assistants_test.rb
@@ -30,6 +30,19 @@ class Settings::AssistantsTest < ApplicationSystemTestCase
     assert_text "Saved"
   end
 
+  test "a second save to the Assistant update page should show the notification again and it should properly dismiss itself" do
+    visit edit_settings_assistant_url(@assistant)
+    click_text "Save"
+    assert_text "Saved"
+    sleep 3.5
+    refute_text "Saved"
+
+    click_text "Save"
+    assert_text "Saved"
+    sleep 3.5
+    refute_text "Saved"
+  end
+
   test "should destroy Assistant" do
     visit edit_settings_assistant_url(@assistant)
     accept_confirm do


### PR DESCRIPTION
I noticed a tricky bug. When I went to settings an updated an assistant by clicking Save on that form, I would see the "Saved" toast appear for 3 seconds and then dismiss itself. But if I then clicked Save on that form again — without reloading the page — the toast would re-appear but the timer would not restart.

This PR adds a test to catch the bug and then it fixes the bug. I fixed this by guaranteeing that a page morph will also morph the toast — if the toast is still present. Then I catch the morphing toast and reconnect the stimulus controller. This is a good general fix for the afterTimeout feature of the transitions controller.