### PR TITLE
Allow nav to open as overlay on mobile

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -74,6 +74,18 @@
   @apply !pl-4
 }
 
+.nav-closed .nav-closed\:hidden {
+  @apply hidden
+}
+
+.nav-closed .nav-closed\:z-auto {
+  @apply z-auto
+}
+
+.nav-closed .nav-closed\:relative {
+  @apply relative
+}
+
 .show-previews .show-previews\:preview-container {
   @apply !flex
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,4 @@
+<% mobile = false %>
 <!DOCTYPE html>
 <html>
   <%= render "head" %>
@@ -6,20 +7,26 @@
       h-screen
       font-sans text-gray-950 dark:text-gray-100
       flex
+      nav-closed
     "
+    data-controller="transition"
+    data-transition-toggle-class="nav-closed"
+    data-transition-target="transitionable"
   >
     <nav
       class="
         h-screen w-[260px]
         bg-gray-50 dark:bg-gray-900
-        hidden md:flex <%= Current.user.preferences[:nav_closed] && "!hidden" %>
+
+        flex nav-closed:hidden <%= !Current.user.preferences[:nav_closed] && "md:!flex" %>
+        z-30 md:z-auto nav-closed:z-auto
+        absolute md:relative nav-closed:relative
         overflow-x-clip
-        relative
         flex-col
       "
     >
       <div id="nav-container" class="flex-1 flex flex-col h-screen">
-        <div id="nav-scrollable" class="flex-grow pl-3 overflow-y-auto overflow-x-clip scrollbar-hide">
+        <div id="nav-scrollable" class="flex-grow pl-3 overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain">
           <%= yield :nav_column %>
         </div>
 
@@ -43,6 +50,12 @@
         <% end %>
       </div>
     </nav>
+
+    <div
+      id="mobile-nav-overlay"
+      class="fixed inset-0 bg-black z-20 bg-opacity-40 md:hidden nav-closed:hidden"
+      data-action="click->transition#toggleClass"
+    ></div>
 
     <main class="flex flex-1 h-screen bg-white dark:bg-gray-800">
       <%= content_for?(:main) ? yield(:main) : yield %>

--- a/app/views/messages/_main_column.html.erb
+++ b/app/views/messages/_main_column.html.erb
@@ -83,9 +83,14 @@
 
   <header id="narrow-header" class="flex-none text-lg text-center h-14 md:hidden">
     <div class="flex items-center justify-between flex-1 mb-2 border-b border-gray-300 text-gray-950 dark:text-gray-100 dark:border-gray-600 dark:bg-gray-800">
-      <div class="inline-flex px-2 ml-1 cursor-pointer group">
+      <%= button_tag type: "button",
+        class: "inline-flex px-2 ml-1 cursor-pointer group",
+        data: {
+          action: "transition#toggleClass"
+        } do
+      %>
         <%= icon "bars-3", variant: :outline, size: 22, class: 'stroke-2 text-gray-950 dark:text-gray-100', title: "Menu", tooltip: :right %>
-      </div>
+      <% end %>
 
       <%= render 'messages/main_column/assistant_header' %>
 
@@ -96,9 +101,9 @@
   </header>
   <!-- end header possibilities -->
 
-  <section class="flex flex-col flex-grow overflow-y-auto bg-white dark:bg-gray-800 overflow-x-clip" data-controller="scrollable" data-scrollable-not-bottom-class="!block">
+  <section class="flex flex-col flex-grow overflow-y-auto bg-white dark:bg-gray-800 overflow-x-clip scrollbar-hide" data-controller="scrollable" data-scrollable-not-bottom-class="!block">
 
-    <div id="messages" class="relative flex-grow overflow-y-auto overflow-x-clip" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">
+    <div id="messages" class="relative flex-grow overflow-y-auto overflow-x-clip scrollbar-hide overscroll-contain" data-scrollable-target="scrollable" data-action="scroll->scrollable#scrolled">
       <div class="w-full md:max-w-none lg:max-w-[700px] xl:max-w-[810px] mx-auto mt-2">
         <%= yield :messages %>
       </div>


### PR DESCRIPTION
There is a new mode for the sidebar that can be triggered when it auto-hides on smaller viewport:

<img width="425" alt="image" src="https://github.com/the-dot-bot/hostedgpt/assets/35061/5678ad07-71b7-491c-abb3-4c2c2bb43443">
